### PR TITLE
fix for newer format as produced by darekkay/todoist-export

### DIFF
--- a/parse_todoist.py
+++ b/parse_todoist.py
@@ -58,13 +58,19 @@ def parse_items(todoist: dict, ids: Dict[int, Any]) -> None:
             continue
 
         item_obj = Item(item["content"], item["checked"],
-                        item["description"], item["date_added"])
+                        item["description"], item["added_at"])
 
         for label in item["labels"]:
-            if label not in ids:
-                print(f"Label {label} not found for item {item['name']}")
-                continue
-            item_obj.labels.append(ids[label])
+            # if label is numeric but string, it's a label ID
+            if label.isnumeric():
+                if label not in ids:
+                    print(f"Label {label} not found for item {item['content']}")
+                    continue
+                else:
+                    item_obj.labels.append(ids[label])
+            else:
+                # its a string, so it's a label name
+                item_obj.labels.append(label)
 
         parent_found = False
         if item["parent_id"] is not None:


### PR DESCRIPTION
Now items are slightly different - labels are directly in JSON and added date are renamed, for example:

```json
"items": {
{
      "added_at": "2018-09-30T20:27:26.000000Z",
      "added_by_uid": null,
      "assigned_by_uid": "10234982",
      "checked": false,
      "child_order": 1,
      "collapsed": false,
      "completed_at": null,
      "content": "Biking",
      "day_order": -1,
      "description": "",
      "due": null,
      "id": "2837318728",
      "is_deleted": false,
      "labels": [
        "Sports"
      ],
      "parent_id": "2837318647",
      "priority": 1,
      "project_id": "1529875619",
      "responsible_uid": null,
      "section_id": null,
      "sync_id": null,
      "user_id": "10234982"
    },
}
```